### PR TITLE
修复slot内容点击事件不生效的问题

### DIFF
--- a/src/components/myClass.vue
+++ b/src/components/myClass.vue
@@ -18,7 +18,10 @@
       <div ref="slotList" :style="float">
         <slot></slot>
       </div>
-      <div v-html="copyHtml" :style="float"></div>
+      <div :style="float">
+        <slot></slot>
+      </div>
+      <!-- <div v-html="copyHtml" :style="float"></div> -->
     </div>
   </div>
 </template>


### PR DESCRIPTION
第二份copy出来的html内容click事件无法生效，所以使用slot替代