### PR TITLE
fix: vueSeamlessScroll组件复制出来的dom不能还原绑定事件问题

### DIFF
--- a/src/components/myClass.vue
+++ b/src/components/myClass.vue
@@ -28,7 +28,7 @@
       <div ref="slotList" :style="float">
         <slot></slot>
       </div>
-      <div v-html="copyHtml" :style="float"></div>
+      <div v-if="scrollSwitch" :style="float"><slot></slot><div>
     </div>
   </div>
 </template>
@@ -44,7 +44,6 @@
         xPos: 0,
         yPos: 0,
         delay: 0,
-        copyHtml: '',
         height: 0,
         width: 0, // 外容器宽度
         realBoxWidth: 0, // 内容实际宽度
@@ -319,7 +318,6 @@
           const { switchDelay } = this.options
           const { autoPlay, isHorizontal } = this
           this._dataWarm(this.data)
-          this.copyHtml = '' //清空copy
           if (isHorizontal) {
             this.height = this.$refs.wrap.offsetHeight
             this.width = this.$refs.wrap.offsetWidth
@@ -346,7 +344,6 @@
           if (this.scrollSwitch) {
             let timer
             if (timer) clearTimeout(timer)
-            this.copyHtml = this.$refs.slotList.innerHTML
             setTimeout(() => {
               this.realBoxHeight = this.$refs.realBox.offsetHeight
               this._move()


### PR DESCRIPTION
使用过程中发现该插件无法还原绑定的事件问题，因此做了修改。测试了[guide](https://chenxuan0000.github.io/vue-seamless-scroll/guide)中的用例，并没有发现问题，所以请求review并合并代码